### PR TITLE
Tag fixes

### DIFF
--- a/data/tags.lua
+++ b/data/tags.lua
@@ -1,80 +1,3 @@
-local function apply_stub(self, _context)
-    if _context.type == "new_blind_choice" then
-        local lock = self.ID
-        G.CONTROLLER.locks[lock] = true
-
-        self:yep("+", G.C.SECONDARY_SET.Cine, function()
-            local key = "p_dvrprv_film_normal_"..(math.random(1, 2))
-            local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2, G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
-                G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty, G.P_CENTERS[key], {
-                    bypass_discovery_center = true,
-                    bypass_discovery_ui = true
-                })
-            card.cost = 0
-            card.from_tag = true
-
-            G.FUNCS.use_card({
-                config = {
-                    ref_table = card
-                }
-            })
-            card:start_materialize()
-            G.CONTROLLER.locks[lock] = nil
-
-            return true
-        end)
-        self.triggered = true
-
-        return true
-    end
-end
-
-local function apply_stamp(self, _context)
-    if _context.type == "new_blind_choice" then
-        self:yep("+", G.C.SECONDARY_SET.Tag, function()
-            local pack_key = "p_dvrprv_tag_jumbo_1"
-            local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2, G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
-                G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty, G.P_CENTERS[pack_key], {
-                    bypass_discovery_center = true,
-                    bypass_discovery_ui = true
-                })
-            card.cost = 0
-            card.from_tag = true
-
-            G.FUNCS.use_card({
-                config = {
-                    ref_table = card
-                }
-            })
-            card:start_materialize()
-
-            if self.name == "Mega Stamp Tag" then
-                local tag = Tag(get_next_tag_key("mega_stamp"))
-
-                if tag.name == "Orbital Tag" then
-                    local poker_hands = {}
-                    for k, v in pairs(G.GAME.hands) do
-                        if v.visible then
-                            table.insert(poker_hands, k)
-                        end
-                    end
-
-                    tag.ability.orbital_hand = pseudorandom_element(poker_hands, pseudoseed("mega_stamp_orbital"))
-                end
-
-                add_tag(tag)
-            end
-
-            G.CONTROLLER.locks[self.ID] = nil
-
-            return true
-        end)
-        self.triggered = true
-
-        return true
-    end
-end
-
 Reverie.tags = {
     {
         key = "cine",
@@ -98,7 +21,37 @@ Reverie.tags = {
 
             return {}
         end,
-        apply = apply_stub
+        apply = function(self, tag, context)
+			if context.type == "new_blind_choice" then
+				local lock = tag.ID
+				G.CONTROLLER.locks[lock] = true
+				
+				tag:yep("+", G.C.SECONDARY_SET.Cine, function()
+					local key = "p_dvrprv_film_normal_1"
+					local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2, G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
+						G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty, G.P_CENTERS[key], {
+							bypass_discovery_center = true,
+							bypass_discovery_ui = true
+					})
+					card.cost = 0
+					card.from_tag = true
+					
+					G.FUNCS.use_card({
+						config = {
+							ref_table = card
+						}
+					})
+					
+					card:start_materialize()
+					G.CONTROLLER.locks[lock] = nil
+					
+					return true
+				end)
+				
+				tag.triggered = true
+				return true
+			end
+		end
     },
     {
         key = "jumbo_tag",
@@ -123,7 +76,34 @@ Reverie.tags = {
 
             return {}
         end,
-        apply = apply_stamp
+        apply = function(self, tag, context)
+			if context.type == "new_blind_choice" then
+				tag:yep("+", G.C.SECONDARY_SET.Tag, function()
+					local pack_key = "p_dvrprv_tag_jumbo_1"
+					local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2, G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
+						G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty, G.P_CENTERS[pack_key], {
+							bypass_discovery_center = true,
+							bypass_discovery_ui = true
+					})
+					card.cost = 0
+					card.from_tag = true
+					
+					G.FUNCS.use_card({
+						config = {
+							ref_table = card
+						}
+					})
+					
+					card:start_materialize()
+					G.CONTROLLER.locks[tag.ID] = nil
+					
+					return true
+				end)
+				
+				tag.triggered = true
+				return true
+			end
+		end
     },
     {
         key = "mega_tag",
@@ -148,7 +128,55 @@ Reverie.tags = {
 
             return {}
         end,
-        apply = apply_stamp,
+        apply = function(self, tag, context)
+			if context.type == "new_blind_choice" then
+				tag:yep("+", G.C.SECONDARY_SET.Tag, function()
+					local pack_key = "p_dvrprv_tag_jumbo_1"
+					local card = Card(G.play.T.x + G.play.T.w / 2 - G.CARD_W * 1.27 / 2, G.play.T.y + G.play.T.h / 2 - G.CARD_H * 1.27 / 2,
+						G.CARD_W * 1.27, G.CARD_H * 1.27, G.P_CARDS.empty, G.P_CENTERS[pack_key], {
+							bypass_discovery_center = true,
+							bypass_discovery_ui = true
+					})
+					card.cost = 0
+					card.from_tag = true
+					
+					G.FUNCS.use_card({
+						config = {
+							ref_table = card
+						}
+					})
+					
+					card:start_materialize()
+					
+					local extra_tag = Tag(get_next_tag_key("mega_stamp"))
+						
+					if extra_tag.name == "Orbital Tag" then
+						local poker_hands = {}
+						for k, v in pairs(G.GAME.hands) do
+							if v.visible then
+								table.insert(poker_hands, k)
+							end
+						end
+						
+						extra_tag.ability.orbital_hand = pseudorandom_element(poker_hands, pseudoseed("mega_stamp_orbital"))
+					end
+					
+					add_tag(extra_tag)
+					
+					for _, v in ipairs(G.GAME.tags) do
+						v:apply_to_run({type = "immediate"})
+					end
+					
+					G.CONTROLLER.locks[tag.ID] = nil
+					
+					return true
+				end)
+				
+				tag.triggered = true
+				return true
+			end
+		end,
+		
         dependency = "CardSleeves"
     }
 }

--- a/localization/en-us.lua
+++ b/localization/en-us.lua
@@ -316,7 +316,7 @@ return {
                     "This Joker gains {C:chips}+#2#{} Chips",
                     "every time an {C:cine}Exchange Coupon",
                     "progresses",
-                    "{C:inactive}(Currently +{C:chips}#1#{C:inactive} Chips)"
+                    "{C:inactive}(Currently {C:chips}+#1#{C:inactive} Chips)"
                 }
             }
         },

--- a/lovely.toml
+++ b/lovely.toml
@@ -130,6 +130,21 @@ if c1.ability.set == "Tag" then
 end'''
 match_indent = true
 
+# Ensures that the second tag created by a Double Tag triggers because if the Mega Stamp Tag
+# generates a Double Tag as its random tag and any immediate tag as its pack tag then the immediate
+# tag gets duplicated but the second copy will only trigger after clearing a blind
+[[patches]]
+[patches.pattern]
+target = "tag.lua"
+pattern = '''add_tag(Tag(_context.tag.key))'''
+position = "after"
+payload = '''
+for _, v in ipairs(G.GAME.tags) do
+        v:apply_to_run({type = "immediate"})
+end
+'''
+match_indent = true
+
 # When Tags are purchased, properly add them to the game and remove from the shop
 # Applying immediate tags is handled in injected update_shop()
 [[patches]]


### PR DESCRIPTION
Hello, I noticed that picking any tags from your mod seemed to freeze the game. This PR fixes that and also tweaks some behaviors such as making sure that the random tag created by the Mega Stamp Tag triggers if it's an immediate one. I also fixed a super minor color typo with the Dynamic Film Joker.

In addition to that I added a patch to the vanilla Double Tag to fix a very weird behavior with the Mega Stamp Tag, I have tested this quite a bit but I am not a Balatro modder, just some idiot who despises lua so I'm not 100% confident that it won't cause issues.